### PR TITLE
Upgrades sbt versions

### DIFF
--- a/sbt/0.13/Dockerfile
+++ b/sbt/0.13/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8
 MAINTAINER Andrew Lawson <https://adlawson.com>
 
-ENV SBT_VERSION=0.13.13
+ENV SBT_VERSION=0.13.17
 
 RUN curl -L -o sbt-$SBT_VERSION.deb http://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
     dpkg -i sbt-$SBT_VERSION.deb && \

--- a/sbt/1.0/Dockerfile
+++ b/sbt/1.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8
 MAINTAINER Andrew Lawson <https://adlawson.com>
 
-ENV SBT_VERSION=1.0.2
+ENV SBT_VERSION=1.2.3
 
 RUN curl -L -o sbt-$SBT_VERSION.deb http://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
     dpkg -i sbt-$SBT_VERSION.deb && \


### PR DESCRIPTION
Hello,

Your Dockerfiles worked like a charm when the `fakeroot` kept blowing up when the `sbt-native-packager` was trying to use it on my macOS HighSierra. 

As a thank you, I upgraded the sbt version to the latest.